### PR TITLE
Release build artifacts to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,20 @@
 
 This is [`git-crypt`][git-crypt] packaged for [Alpine Linux][alpine-linux].
 
+## Releases
+
+See the [releases page][releases] for the latest download links.
+
+## Installing
+
+The current installation method for these packages is to pull them in using
+`wget` or `curl` and install the local file with `apk`:
+
+    apk --no-cache add ca-certificates
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-git-crypt/master/sgerrand.rsa.pub
+    wget https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.5.0-r0/git-crypt-0.5.0-r0.apk
+    apk add git-crypt-0.5.0-r0.apk
+
 [alpine-linux]: https://www.alpinelinux.org
 [git-crypt]: https://www.agwa.name/projects/git-crypt/
+[releases]: https://github.com/sgerrand/alpine-pkg-git-crypt/releases/

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
 
 dependencies:
   pre:
+    - git fetch --tags
+    - go get github.com/tcnksm/ghr
     - mkdir packages
     - echo -e "$RSA_PUBLIC_KEY" > packages/sgerrand.rsa.pub
   override:
@@ -16,3 +18,17 @@ dependencies:
 test:
   override:
     - ./bin/citest $(pwd)/packages
+
+deployment:
+  release:
+    tag: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
+    owner: sgerrand
+    commands:
+      - ghr -u $CIRCLE_PROJECT_USERNAME $CIRCLE_TAG packages/
+      - ghr -u $CIRCLE_PROJECT_USERNAME $CIRCLE_TAG packages/builder/x86_64
+  master:
+    branch: master
+    owner: sgerrand
+    commands:
+      - ghr -u $CIRCLE_PROJECT_USERNAME --prerelease --delete unreleased packages
+      - ghr -u $CIRCLE_PROJECT_USERNAME --prerelease unreleased packages/builder/x86_64


### PR DESCRIPTION
💁  Use CircleCI and [`ghr`](github.com/tcnksm/ghr) to publish build artifacts as GitHub releases.