### PR TITLE
Fix libcrypto alpine 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,14 @@ jobs:
       - run:
           name: Create Docker volumes
           command: |
-            docker create --name input --volume /home/builder/package alpine:3.7 /bin/true
-            docker create --name output --volume /packages alpine:3.7 /bin/true
+            docker create --name input --volume /home/builder/package alpine:3.9 /bin/true
+            docker create --name output --volume /packages alpine:3.9 /bin/true
             docker cp ./APKBUILD input:/home/builder/package/
       - run:
           name: Build packages
           command: |
             docker run --env RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" --env RSA_PRIVATE_KEY_NAME="sgerrand.rsa" \
-                       --volumes-from input --volumes-from output sgerrand/alpine-abuild:3.7
+                       --volumes-from input --volumes-from output sgerrand/alpine-abuild:3.9
       - run:
           name: Extract packages
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,27 @@ jobs:
             mkdir -p packages
             docker cp output:/packages/builder packages/
       - run:
+          name: Remove Docker volumes
+          command: |
+            docker rm input
+            docker rm output
+          when: always
+      - store_artifacts:
+          destination: pkgs
+          path: packages
+      - persist_to_workspace:
+          root: .
+          paths:
+            - sgerrand.rsa.pub
+            - packages
+    working_directory: ~/alpine-pkg-git-crypt
+  test:
+    docker:
+      - image: alpine:3.9
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
           name: Test installing packages
           command: |
             cp sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
@@ -37,19 +58,6 @@ jobs:
             cd $__wdir
             git init
             git-crypt status
-      - run:
-          name: Remove Docker volumes
-          command: |
-            docker rm input
-            docker rm output
-          when: always
-      - store_artifacts:
-          destination: pkgs
-          path: packages
-      - persist_to_workspace:
-          root: .
-          paths:
-            - packages
     working_directory: ~/alpine-pkg-git-crypt
   release-master:
     docker:
@@ -87,6 +95,7 @@ workflows:
       - release-master:
           requires:
             - build
+            - test
           filters:
             branches:
               only: master
@@ -95,8 +104,10 @@ workflows:
       - release-tag:
           requires:
             - build
+            - test
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
             branches:
               ignore: /.*/
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ jobs:
     docker:
       - image: alpine:3.9
     steps:
+      - run:
+          name: Install CA certificates
+          command: apk add --no-cache ca-certificates
       - attach_workspace:
           at: .
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - sgerrand.rsa.pub
             - packages
     working_directory: ~/alpine-pkg-git-crypt
   test:
@@ -44,10 +43,11 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Add package signing key
+          command: wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-git-crypt/master/sgerrand.rsa.pub
+      - run:
           name: Test installing packages
-          command: |
-            cp sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-            apk add --no-progress --no-cache ./packages/builder/x86_64/git-crypt-*.apk
+          command: apk add --no-progress --no-cache ./packages/builder/x86_64/git-crypt-*.apk
       - run:
           name: Test executable
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,4 +110,9 @@ workflows:
               only: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
             branches:
               ignore: /.*/
-      - test
+      - test:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - packages
+            - packages/builder/x86_64
     working_directory: ~/alpine-pkg-git-crypt
   test:
     docker:

--- a/APKBUILD
+++ b/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Sasha Gerrand <alpine-pkgs@sgerrand.com>
 pkgname=git-crypt
 pkgver=0.6.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Transparent file encryption in git"
 url="https://www.agwa.name/projects/git-crypt/"
 arch="all"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The current installation method for these packages is to pull them in using
 
     apk --no-cache add ca-certificates
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-git-crypt/master/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.6.0-r0/git-crypt-0.6.0-r0.apk
-    apk add git-crypt-0.6.0-r0.apk
+    wget https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.6.0-r1/git-crypt-0.6.0-r1.apk
+    apk add git-crypt-0.6.0-r1.apk
 
 [alpine-linux]: https://www.alpinelinux.org
 [git-crypt]: https://www.agwa.name/projects/git-crypt/


### PR DESCRIPTION
💁 The version of `libcrypto` changed in Alpine Linux 3.9. Need to create a new package to accommodate this.

    >>> git-crypt*: Tracing dependencies...
        git
        libgcc
        libstdc++
        openssl
        so:libc.musl-x86_64.so.1
        so:libcrypto.so.1.1
        so:libgcc_s.so.1
        so:libstdc++.so.6