### PR TITLE
Builds for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,10 @@ workflows:
   version: 2
   build-test-release:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
       - release-master:
           requires:
             - build
@@ -118,4 +121,4 @@ workflows:
             - build
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
+              only: /.*/


### PR DESCRIPTION
💁 As per [CircleCI's documentation](https://circleci.com/docs/2.0/configuration-reference/#filters-1):

> CircleCI does not run workflows for tags unless you explicitly specify
> tag filters. Additionally, if a job requires any other jobs (directly
> or indirectly), you must specify tag filters for those jobs.

Updates the CircleCI build configuration to ensure that builds are run for tags, when pushed.